### PR TITLE
Add OCR inference API and Streamlit integration

### DIFF
--- a/custom_inference/config.py
+++ b/custom_inference/config.py
@@ -1,0 +1,14 @@
+class Opt:
+    imgH = 32
+    imgW = 100
+    input_channel = 1
+    batch_max_length = 25
+    character = "0123456789"
+    Transformation = "TPS"
+    FeatureExtraction = "ResNet"
+    SequenceModeling = "BiLSTM"
+    Prediction = "Attn"
+    num_fiducial = 20
+    output_channel = 512
+    hidden_size = 256
+    num_class = len(character) + 2

--- a/database.py
+++ b/database.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    db_host: str = "localhost"
+    db_port: int = 5432
+    db_user: str = "postgres"
+    db_pass: str = "postgres"
+    db_name: str = "postgres"
+    db_echo: bool = False
+
+    class Config:
+        env_file = os.getenv("ENV_FILE", ".env")
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()
+
+DATABASE_URL = (
+    f"postgresql+asyncpg://{settings.db_user}:{settings.db_pass}"
+    f"@{settings.db_host}:{settings.db_port}/{settings.db_name}"
+)
+
+engine = create_async_engine(DATABASE_URL, echo=settings.db_echo)
+AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+Base = declarative_base()
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/main.py
+++ b/main.py
@@ -1,12 +1,51 @@
-from fastapi import FastAPI
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from fastapi import FastAPI, File, UploadFile, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from custom_inference.config import Opt
+from custom_inference.ocr_inference import load_model_and_converter, predict_text
+from database import Base, engine, get_session
+from models import Recognition
+
+
+opt = Opt()
+ocr_model, ocr_converter = load_model_and_converter(opt, "ocr_weights.pth", device="cpu")
+
+
+async def init_models() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
 
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Video Inference API")
 
+    @app.on_event("startup")
+    async def on_startup() -> None:
+        await init_models()
+
     @app.get("/ping")
     async def ping():
         return {"status": "ok"}
+
+    @app.post("/predict")
+    async def predict(file: UploadFile = File(...), session: AsyncSession = Depends(get_session)) -> dict[str, str]:
+        data = await file.read()
+        np_arr = np.frombuffer(data, np.uint8)
+        frame = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        if frame is None:
+            raise HTTPException(status_code=400, detail="Invalid image")
+
+        text = predict_text(ocr_model, ocr_converter, frame, opt)
+
+        rec = Recognition(text=text)
+        session.add(rec)
+        await session.commit()
+
+        return {"text": text}
 
     return app
 

--- a/models.py
+++ b/models.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, Integer, String, func
+
+from .database import Base
+
+
+class Recognition(Base):
+    __tablename__ = "recognitions"
+
+    id = Column(Integer, primary_key=True)
+    text = Column(String(256), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,9 @@
 import cv2
 import tempfile
 import time
+from typing import Optional
+
+import requests
 import streamlit as st
 from custom_inference.yolo_inference import load_model, inference
 
@@ -11,12 +14,30 @@ def get_model():
     return load_model("best.pt")
 
 
-def draw_boxes(frame, detections):
+API_URL = "http://localhost:8000/predict"
+
+
+def get_text(frame) -> Optional[str]:
+    _, encoded = cv2.imencode(".jpg", frame)
+    files = {"file": ("frame.jpg", encoded.tobytes(), "image/jpeg")}
+    try:
+        resp = requests.post(API_URL, files=files, timeout=5)
+        if resp.status_code == 200:
+            return resp.json().get("text")
+    except Exception:
+        return None
+    return None
+
+
+def draw_boxes(frame, detections, text: Optional[str] = None):
     for det in detections:
         x, y, w, h = map(int, det["box"])
         cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
         label = f"{det['class_id']}:{det['confidence']:.2f}"
         cv2.putText(frame, label, (x, y - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+
+    if text:
+        cv2.putText(frame, text, (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 0, 0), 2)
     return frame
 
 
@@ -31,14 +52,18 @@ if uploaded and st.button("Run Inference"):
     model = get_model()
     cap = cv2.VideoCapture(tfile.name)
     frame_placeholder = st.empty()
+    text_placeholder = st.empty()
 
     while cap.isOpened():
         ret, frame = cap.read()
         if not ret:
             break
         detections = inference(model, frame)
-        annotated = draw_boxes(frame, detections)
+        text = get_text(frame)
+        annotated = draw_boxes(frame, detections, text)
         frame_placeholder.image(annotated, channels="BGR")
+        if text:
+            text_placeholder.write(f"Recognized: {text}")
         time.sleep(0.03)
 
     cap.release()


### PR DESCRIPTION
## Summary
- add async SQLAlchemy setup and table for recognized texts
- provide OCR config class
- create `/predict` endpoint in FastAPI that runs OCR and logs to PostgreSQL
- update Streamlit demo to call FastAPI and show recognized text over video

## Testing
- `pre-commit run --files main.py streamlit_app.py custom_inference/config.py database.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_6859b8ccd798832e847a1032c184ff31