### PR TITLE
Add model path configuration via env vars

### DIFF
--- a/exmaple.env
+++ b/exmaple.env
@@ -5,4 +5,7 @@ DB_PASS=postgres
 DB_NAME=dbname
 DB_ECHO=True
 
-
+# Absolute paths to model weights
+# OCR model (.pth) and YOLO model (.pt)
+OCR_MODEL_PATH=/abs/path/to/custom_inference/models/ocr/best_accuracy.pth
+YOLO_MODEL_PATH=/abs/path/to/custom_inference/models/yolo/best.pt

--- a/main.py
+++ b/main.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import cv2
 import numpy as np
-from fastapi import FastAPI, File, UploadFile, Depends, HTTPException
+from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from custom_inference.config import Opt
-from custom_inference.ocr_inference import load_model_and_converter, predict_text, get_device
+from custom_inference.ocr_inference import (
+    get_device,
+    load_model_and_converter,
+    predict_text,
+)
 from database import Base, engine, get_session
 from models import Recognition
 
 
+ROOT_DIR = Path(__file__).resolve().parent
+DEFAULT_OCR_MODEL_PATH = ROOT_DIR / "custom_inference" / "models" / "ocr" / "best_accuracy.pth"
+
 opt = Opt()
-ocr_model, ocr_converter = load_model_and_converter(opt, "ocr/best_accuracy.pth", device=get_device())
+ocr_weights = os.getenv("OCR_MODEL_PATH", str(DEFAULT_OCR_MODEL_PATH))
+ocr_model, ocr_converter = load_model_and_converter(opt, ocr_weights, device=get_device())
 
 
 async def init_models() -> None:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import cv2
 import tempfile
 import time
@@ -5,13 +8,17 @@ from typing import Optional
 
 import requests
 import streamlit as st
-from custom_inference.yolo_inference import load_model, inference
+from custom_inference.yolo_inference import inference, load_model
+
+ROOT_DIR = Path(__file__).resolve().parent
+DEFAULT_YOLO_MODEL_PATH = ROOT_DIR / "custom_inference" / "models" / "yolo" / "best.pt"
+YOLO_MODEL_PATH = os.getenv("YOLO_MODEL_PATH", str(DEFAULT_YOLO_MODEL_PATH))
 
 
 @st.cache_resource
 def get_model():
     # Downloads pretrained weights on first run
-    return load_model("best.pt")
+    return load_model(YOLO_MODEL_PATH)
 
 
 API_URL = "http://localhost:8000/predict"


### PR DESCRIPTION
## Summary
- add environment variable defaults for OCR/YOLO model weights
- update `streamlit_app.py` and `main.py` to read paths from env
- document the new variables in `exmaple.env`

## Testing
- `pre-commit run --files main.py streamlit_app.py exmaple.env`

------
https://chatgpt.com/codex/tasks/task_e_6859c366e3fc832ebd0bf10dbe99092a